### PR TITLE
fix: handle empty values & accept non-string values

### DIFF
--- a/addon/helpers/css-properties.js
+++ b/addon/helpers/css-properties.js
@@ -12,7 +12,7 @@ export function cssProperties([objStyles = {}], hashStyles = {}) {
 
     if (isEmpty(propertyValue)) continue;
 
-    const [singlePropertyValue] = propertyValue.split(';');
+    const [singlePropertyValue] = String(propertyValue).split(';');
 
     stringStyles += `${cssesc(propertyName)}:${cssesc(singlePropertyValue)};`;
   }

--- a/addon/helpers/css-properties.js
+++ b/addon/helpers/css-properties.js
@@ -1,5 +1,6 @@
 import { helper } from '@ember/component/helper';
 import { htmlSafe } from '@ember/string';
+import { isEmpty } from '@ember/utils';
 import cssesc from 'cssesc';
 
 export function cssProperties([objStyles = {}], hashStyles = {}) {
@@ -8,6 +9,9 @@ export function cssProperties([objStyles = {}], hashStyles = {}) {
 
   for (const propertyName in allStyles) {
     const propertyValue = allStyles[propertyName];
+
+    if (isEmpty(propertyValue)) continue;
+
     const [singlePropertyValue] = propertyValue.split(';');
 
     stringStyles += `${cssesc(propertyName)}:${cssesc(singlePropertyValue)};`;

--- a/tests/integration/helpers/css-properties-test.js
+++ b/tests/integration/helpers/css-properties-test.js
@@ -68,3 +68,17 @@ test('it should ignore empty values', function(assert) {
   assert.notOk(el.style.width);
   assert.notOk(el.style.backgroundImage);
 });
+
+test('it should accept non-string values', function(assert) {
+  let myStyles = {
+    'line-height': 1.5
+  };
+
+  this.set('myStyles', myStyles);
+
+  this.render(hbs`<div data-test-mystyle style="{{css-properties myStyles}}"></div>`);
+
+  let el = this.$('[data-test-mystyle]')[0];
+
+  assert.equal(el.style.lineHeight, '1.5');
+});

--- a/tests/integration/helpers/css-properties-test.js
+++ b/tests/integration/helpers/css-properties-test.js
@@ -30,7 +30,7 @@ test('it should escape malicious property values', function(assert) {
   assert.notEqual(el2.css('width'), '10px', 'Malicious values are not made into valid values');
 });
 
-test('it should allow object invokation', function(assert) {
+test('it should allow object invocation', function(assert) {
   let myStyles = {
     color: 'red',
     width: '20%',
@@ -48,4 +48,23 @@ test('it should allow object invokation', function(assert) {
 
   /*eslint no-useless-escape: 0*/
   assert.equal(el.style.backgroundImage, `url(\"http://placecage.com/200/200\")`);
+});
+
+test('it should ignore empty values', function(assert) {
+  let myStyles = {
+    color: 'red',
+    width: undefined,
+    'background-image': null
+  };
+
+  this.set('myStyles', myStyles);
+
+  this.render(hbs`<div data-test-mystyle style="{{css-properties myStyles}}"></div>`);
+
+  let el = this.$('[data-test-mystyle]')[0];
+
+  assert.equal(el.style.color, 'red');
+
+  assert.notOk(el.style.width);
+  assert.notOk(el.style.backgroundImage);
 });


### PR DESCRIPTION
Previously these invocations would have crashed:

```hbs
{{css-properties width=undefined}}
````

```hbs
{{css-properties line-height=1.5}}
````